### PR TITLE
支持检测更长的固件名

### DIFF
--- a/serial_utils.py
+++ b/serial_utils.py
@@ -89,7 +89,8 @@ def sayhello(serial_port: serial.Serial):
                 raise Exception("没有收到电台应答包！")
     except Exception as e:
         raise Exception("没有收到电台应答包！<-" + str(e))
-    firmware = get_string(o, 4, 16)
+    #log(len(o))
+    firmware = get_string(o, 4, len(o))
     return firmware
 
 


### PR DESCRIPTION
如果hello数据包固件名之后没有其他数据的话，可以采用此方法，一劳永逸。